### PR TITLE
Fix SSPX 2.5m Greenhouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   stress and radiation. When under stress they can make mistakes, some do better than others. (Sir Mortimer)
 * A laboratory with high level crew members in it will work faster (Sir Mortimer)
 * Harvesters will work better with an engineer on board. (Sir Mortimer)
+* SSPX 2.5m Greenhouse now producing food at the expected rate. (theJesuit)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -469,7 +469,7 @@
 	// This greenhouse has 18 independent sections! It's 18 staged crops in rotation. Almost non-stop production, but each harvest is 18 times smaller.
 	
 	crop_size = 3.0625			// 18 times less harvest than 2x"kerbalism-greenhouse"
-    crop_rate = 0.00172265625           // but you can harvest 18 times more often due to independent sections!
+    crop_rate = 0.00000416664           // but you can harvest 18 times more often due to independent sections!
 	
     ec_rate = 5                      // 2x"kerbalism-greenhouse"
 


### PR DESCRIPTION
This 2.5 SSPX greenhouse was producing just over 3kg of food every 10 or so minutes.

_Kerbals were having to eat faster and faster to keep up.  At the KSC, Linus wanted to know how it happened, Gus was concerned that Jeb was spending more time eating than piloting and Wernher was considering how this could be utilised as a propulsion source, turning this part into a Vomit Comet.  As much as Gene was taken with a re-purposing a malfunctioning part to complete a mission, Mortimer reminded him that the PAID for engines still worked fine.  Someone through a patch over the part and all was well._

Reduced the crop rate from the accidental high mentioned above to the expected 11 day turn around based 1/18 of the SSPX 3.75m time and crop rate.